### PR TITLE
feat(token): support token sweep

### DIFF
--- a/contracts/RariGovernanceToken.sol
+++ b/contracts/RariGovernanceToken.sol
@@ -21,12 +21,6 @@ import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Paus
  * @notice RariGovernanceToken is the contract behind the Rari Governance Token (RGT), an ERC20 token accounting for the ownership of Rari Stable Pool, Yield Pool, and Ethereum Pool.
  */
 contract RariGovernanceToken is Initializable, ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
-
-    /**
-     * @dev Address of sweep recipient.
-     */
-    address private _sweeper;
-
     /**
      * @dev Initializer that reserves 8.75 million RGT for liquidity mining and 1.25 million RGT to the team/advisors/etc.
      */
@@ -38,21 +32,9 @@ contract RariGovernanceToken is Initializable, ERC20, ERC20Detailed, ERC20Burnab
     }
 
     /**
-     * @dev Migration function that sets the sweeper address for the contract. The migration can only be run once
-     * which is enforced using the value of the sweeper address. This function should be executed using `upgradeToAndCall`
-     * during the migration process.
-     */
-    function migration(address sweeper) public {
-        require(address(_sweeper) == address(0), "Sweeper is already initialized.");
-        require(address(sweeper) != address(0), "Sweeper cannot be the zero address.");
-        _sweeper = sweeper;
-    }
-
-    /**
      * @dev Sweep transfers the current RGT token balance of the token contract to the configured recipient.
      */
-    function sweep() public {
-        require(address(_sweeper) != address(0), "Sweeper cannot be the zero address.");
-        _transfer(address(this), _sweeper, balanceOf(address(this)));
+    function sweep() public onlyPauser {
+        _transfer(address(this), msg.sender, balanceOf(address(this)));
     }
 }


### PR DESCRIPTION
This pull request adds support for sweeping any RGT token balance in the token contract to a designated sweeper address. For simplicity, the sweeper address is only set once during migration. The assumption is that we can set it to the RGT DAO/Multisig which will receive the swept tokens and can deal with distribution. The `sweeper` method itself is public so anyone can trigger a sweep to the sweep recipient. This simplifies the coordination of the sweep since the affected party can initialize the process.

I'll note here that the distribution of the swept funds is up to the discretion of the RGT governance process. So it is not guaranteed that swept funds will be returned to the affected party. I believe the process would be robust enough to do the right thing though so we can offload the smart contract complexity.